### PR TITLE
Made `hylaa` pip-installable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 # Based on: 
-# https://dzone.com/articles/executable-package-pip-install
+# https://betterscientificsoftware.github.io/
+# python-for-hpc/tutorials/python-pypi-packaging/
 
 from setuptools import setup
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+# Based on: 
+# https://dzone.com/articles/executable-package-pip-install
+
+from setuptools import setup
+
+setup(
+    name='hylaa',
+    version='2.0',    
+    description='A example Python package',
+    url='https://github.com/shuds13/pyexample',
+    author='Stephen Hudson',
+    author_email='shudson@anl.gov',
+    license='BSD 2-clause',
+    packages=['hylaa'],
+    install_requires=['ffmpeg',
+                      'pytest', 
+                      'numpy', 
+                      'scipy', 
+                      'sympy', 
+                      'matplotlib', 
+                      'termcolor',
+                      'swiglpk', 
+                      'graphviz'
+                      ]
+)


### PR DESCRIPTION
Per [my issue](https://github.com/stanleybak/hylaa/issues/7), I went ahead and worked out how to make `hylaa` pip-installable.

Now you can install locally by just running `pip install .` from `hylaa/`.