### PR TITLE
Metadata Cleanup, Release 2.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Hylaa #
 
-<p align="center"> <img src="hylaa_logo_small.png" alt="Hylaa Logo"/> </p>
+<p align="center"> <img src="https://github.com/stanleybak/hylaa/blob/master/hylaa_logo_small.png" alt="Hylaa Logo"/> </p>
 
 Hylaa (**HY**brid **L**inear **A**utomata **A**nalyzer) is a verification tool for system models with linear ODEs, time-varying inputs, and possibly hybrid dynamics. 
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 [![Build Status](https://travis-ci.org/stanleybak/hylaa.svg?branch=master)](https://travis-ci.org/stanleybak/hylaa)
+[![PyPI version](https://badge.fury.io/py/hylaa.svg)](https://badge.fury.io/py/hylaa)
 
 # Hylaa #
 
-<p align="center"> <img src="https://github.com/stanleybak/hylaa/blob/master/hylaa_logo_small.png" alt="Hylaa Logo"/> </p>
+<p align="center"> <img src="https://raw.githubusercontent.com/stanleybak/hylaa/master/hylaa_logo_small.png" alt="Hylaa Logo"/> </p>
 
 Hylaa (**HY**brid **L**inear **A**utomata **A**nalyzer) is a verification tool for system models with linear ODEs, time-varying inputs, and possibly hybrid dynamics. 
 

--- a/hylaa/__init__.py
+++ b/hylaa/__init__.py
@@ -4,3 +4,14 @@ __all__ = []
 
 from . import _version
 __version__ = _version.get_versions()['version']
+__author__ = "Stanley Bak"
+__copyright__ = "Copyright 2023"
+__credits__ = [
+   "Stanley Bak",
+   "Hoang-Dung Tran",
+   "Max von Hippel" 
+]
+__license__ = "GPLv3"
+__maintainer__ = "Stanley Bak"
+__email__ = "bak2007-DONTSENDMEEMAIL@gmail.com"
+__status__ = "Prototype"

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,16 @@
 from setuptools import setup
 import versioneer
 
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
 setup(
     name="hylaa",
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     description="Hylaa",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     url="https://github.com/stanleybak/hylaa",
     author="Stanley Bak",
     author_email="bak2007-DONTSENDMEEMAIL@gmail.com",
@@ -25,5 +30,13 @@ setup(
         "termcolor",
         "swiglpk",
         "graphviz",
+    ],
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "Operating System :: OS Independent",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "Intended Audience :: Science/Research",
+        "Topic :: Scientific/Engineering"
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     license="GPLv3",
     packages=["hylaa"],
     install_requires=[
-        "ffmpeg",
+        "ffmpeg-python",
         "pytest",
         "numpy",
         "scipy",


### PR DESCRIPTION
Some cleanup for polished PyPI entry. The package is published! https://pypi.org/project/hylaa/ 

I would be happy to address any issues with more point releases (v2.0.x).

**Notes**
* It might make sense to pin versions of python and deps because not all examples work for the latest versions of these libraries. 
* I couldn't fully automate publishing on PyPI because I couldn't add secrets to the repository. Full automation will work if the secrets TEST_PYPI_API_TOKEN and PYPI_API_TOKEN are added. See here: https://github.com/stanleybak/hylaa/blob/master/.github/workflows/publish-package.yml#L41
* Most importantly @stanleybak , I own the PyPI listing as I did it under my account. I can transfer ownership once I know your account name.


